### PR TITLE
Add Class Template Middleman Class to CAN Library

### DIFF
--- a/dev-board/Src/main.cpp
+++ b/dev-board/Src/main.cpp
@@ -101,7 +101,7 @@ int main(void)
   RF_PACKET msg0{huart2.Instance};
   BMS_MESSAGE_0_DATA_PACKET test{1.2 , 22.1, 33.55, 4.87};
   CAN_TO_RF::AddMessage(&msg0, CAN_TO_RF::CAN_MSG_RF_ADDR::BMS, &test);
-  test.arrayVoltage = 33;
+  test.avgCellVoltage = 33;
   CAN_TO_RF::AddMessage(&msg0, CAN_TO_RF::CAN_MSG_RF_ADDR::BMS, &test);
   msg0.Send();
   CAN_TO_RF::AddMessage(&msg0, CAN_TO_RF::CAN_MSG_RF_ADDR::BMS, &test);

--- a/dev-board/rf-messaging-module/can-message-helper.cpp
+++ b/dev-board/rf-messaging-module/can-message-helper.cpp
@@ -35,14 +35,14 @@ namespace CAN_TO_RF
                 {
                     case CAN_MSG_RF_ADDR::MPPT:
                     {
-                        actualMessageSize = MPPT0_HELPER::ARRAY_SIZE;
-                        MPPT0_HELPER::dataPacketToArray(*static_cast<MPPT_MESSAGE_0_DATA_PACKET*>(tx_msg), convertedData);
+                        actualMessageSize = MPPT_MESSAGE_0::NUM_BYTES;
+                        MPPT_MESSAGE_0::dataPacketToArray(*static_cast<MPPT_MESSAGE_0_DATA_PACKET*>(tx_msg), convertedData);
                         break;
                     }
                     case CAN_MSG_RF_ADDR::BMS:
                     {
-                        actualMessageSize = BMS0_HELPER::ARRAY_SIZE;
-                        BMS0_HELPER::dataPacketToArray(*static_cast<BMS_MESSAGE_0_DATA_PACKET*>(tx_msg), convertedData);
+                        actualMessageSize = BMS_MESSAGE_0::NUM_BYTES;
+                        BMS_MESSAGE_0::dataPacketToArray(*static_cast<BMS_MESSAGE_0_DATA_PACKET*>(tx_msg), convertedData);
                         break;
                     }
                 }

--- a/dev-board/subsystem-can-driver/aux-data-module.cpp
+++ b/dev-board/subsystem-can-driver/aux-data-module.cpp
@@ -27,54 +27,31 @@
 //Private Function Definitions
 
 //Protected Function Definitions
-namespace AUX0_HELPER
+void AUX_MESSAGE_0::dataPacketToArray(AUX_MESSAGE_0_DATA_PACKET input, uint8_t output[NUM_BYTES])
 {
-	void dataPacketToArray(AUX_MESSAGE_0_DATA_PACKET input, uint8_t output[ARRAY_SIZE])
-	{
-		assert_param(output != nullptr);
-		output[0] = 0;
+	assert_param(output != nullptr);
+	output[0] = 0;
 
-		output[0] |= static_cast<uint32_t>(input.hazardsOn) << 0;
-		output[0] |= static_cast<uint32_t>(input.headlightsOn) << 1;
-		output[0] |= static_cast<uint32_t>(input.leftOn) << 2;
-		output[0] |= static_cast<uint32_t>(input.rightOn) << 3;
-	}
-
-	AUX_MESSAGE_0_DATA_PACKET arrayToDataPacket(uint8_t input[ARRAY_SIZE])
-	{
-		assert_param(input != nullptr);
-
-		AUX_MESSAGE_0_DATA_PACKET output;
-		output.hazardsOn = input[0] & (1 << 0);
-		output.headlightsOn = input[0] & (1 << 1);
-		output.leftOn = input[0] & (1 << 2);
-		output.rightOn = input[0] & (1 << 3);
-
-		return output;
-	}
+	output[0] |= static_cast<uint32_t>(input.hazardsOn) << 0;
+	output[0] |= static_cast<uint32_t>(input.headlightsOn) << 1;
+	output[0] |= static_cast<uint32_t>(input.leftOn) << 2;
+	output[0] |= static_cast<uint32_t>(input.rightOn) << 3;
 }
 
-void AUX_MESSAGE_0::fillTransmitBuffer(void)
+AUX_MESSAGE_0_DATA_PACKET AUX_MESSAGE_0::arrayToDataPacket(uint8_t input[NUM_BYTES])
 {
-	AUX0_HELPER::dataPacketToArray(this->txData, this->transmitBuffer);
+	assert_param(input != nullptr);
+
+	AUX_MESSAGE_0_DATA_PACKET output;
+	output.hazardsOn = input[0] & (1 << 0);
+	output.headlightsOn = input[0] & (1 << 1);
+	output.leftOn = input[0] & (1 << 2);
+	output.rightOn = input[0] & (1 << 3);
+
+	return output;
 }
+
 //Public Function Definitions
 AUX_MESSAGE_0::AUX_MESSAGE_0():
-SUBSYSTEM_DATA_MODULE{subsystem_info::AUX0_MSG_ID,subsystem_info::AUX0_MSG_LENGTH, false}
+SUBSYSTEM_DATA_MODULE_TEMPLATE_INTERFACE<AUX_MESSAGE_0, AUX_MESSAGE_0_DATA_PACKET>{subsystem_info::AUX0_MSG_ID,subsystem_info::AUX0_MSG_LENGTH, false}
 {}
-
-AUX_MESSAGE_0_DATA_PACKET AUX_MESSAGE_0::GetOldestDataPacket(bool* success)
-{
-	AUX_MESSAGE_0_DATA_PACKET returnData;
-    if(success)
-    {
-        uint8_t* raw_data = this->storageFifo.PopFront(success);
-
-        //Only do the conversions if we successfully extracted from the fifo
-        if(*success)
-        {
-        	returnData = AUX0_HELPER::arrayToDataPacket(raw_data);
-        }
-    }
-    return returnData;
-}

--- a/dev-board/subsystem-can-driver/aux-data-module.hpp
+++ b/dev-board/subsystem-can-driver/aux-data-module.hpp
@@ -42,47 +42,32 @@ struct AUX_MESSAGE_0_DATA_PACKET
 	bool headlightsOn;
 };
 
-namespace AUX0_HELPER
-{
-	static constexpr uint8_t ARRAY_SIZE = 1;
-	/**
-	 * @brief This function converts @input to fill the encoded @output array
-	 * @param input: Data to be converted
-	 * @param output: Array that should be allocated at least @ARRAY_SIZE bytes
-	 */
-	void dataPacketToArray(AUX_MESSAGE_0_DATA_PACKET input, uint8_t output[ARRAY_SIZE]);
-	/**
-	 * @brief This converts the encoded @input array to a data packet
-	 * @param input: Encoded array of @ARRAY_SIZE bytes
-	 * @retval A data packet
-	 */
-	AUX_MESSAGE_0_DATA_PACKET arrayToDataPacket(uint8_t input[ARRAY_SIZE]);
-}
 
-class AUX_MESSAGE_0 final: public SUBSYSTEM_DATA_MODULE
+class AUX_MESSAGE_0 final: public SUBSYSTEM_DATA_MODULE_TEMPLATE_INTERFACE<AUX_MESSAGE_0, AUX_MESSAGE_0_DATA_PACKET>
 {
 public:
 //Constructors
 AUX_MESSAGE_0();
+//Public Constants
+static constexpr uint8_t NUM_BYTES = 1;
 //Public Function Prototypes
 /**
- * @brief This is used to get the first in data packet.
- * @param success: returns true if there was data to get, false if the fifo was empty
- * @return Corresponding mppt data packet
+ * @brief This function converts @input to fill the encoded @output array
+ * @param input: Data to be converted
+ * @param output: Array that should be allocated at least @ARRAY_SIZE bytes
  */
-AUX_MESSAGE_0_DATA_PACKET GetOldestDataPacket(bool* success);
-//Public Constants
-
+static void dataPacketToArray(AUX_MESSAGE_0_DATA_PACKET input, uint8_t output[NUM_BYTES]);
+/**
+ * @brief This converts the encoded @input array to a data packet
+ * @param input: Encoded array of @ARRAY_SIZE bytes
+ * @retval A data packet
+ */
+static AUX_MESSAGE_0_DATA_PACKET arrayToDataPacket(uint8_t input[NUM_BYTES]);
 //Public Variables
 /**
  * @brief Fill this out prior to calling SendData()
  */
 AUX_MESSAGE_0_DATA_PACKET txData;
-private:
-//Private Constants
-//Private Variables
-//Private Function Prototypes
-void fillTransmitBuffer(void) override;
 };
 
 #endif //End Header Guard

--- a/dev-board/subsystem-can-driver/bms-data-module.cpp
+++ b/dev-board/subsystem-can-driver/bms-data-module.cpp
@@ -27,62 +27,40 @@
 //Private Function Definitions
 
 //Protected Function Definitions
-namespace BMS0_HELPER
+void BMS_MESSAGE_0::dataPacketToArray(BMS_MESSAGE_0_DATA_PACKET input, uint8_t output[NUM_BYTES])
 {
-	void dataPacketToArray(BMS_MESSAGE_0_DATA_PACKET input, uint8_t output[ARRAY_SIZE])
-	{
-		float convLowCellVoltage = input.lowCellVoltage * 1;
-		float convHighCellVoltage = input.highCellVoltage * 1;
-		float convAvgCellVoltage = input.avgCellVoltage * 1;
-		float convPackSummedVoltage = input.packSummedVoltage * 1;
+	float convLowCellVoltage = input.lowCellVoltage * 1;
+	float convHighCellVoltage = input.highCellVoltage * 1;
+	float convAvgCellVoltage = input.avgCellVoltage * 1;
+	float convPackSummedVoltage = input.packSummedVoltage * 1;
 
-		output[0] = static_cast<uint32_t>(convLowCellVoltage) & 0xFF;
-		output[1] = (static_cast<uint32_t>(convLowCellVoltage) >> 8) & 0xFF;
-		output[2] = static_cast<uint32_t>(convHighCellVoltage) & 0xFF;
-		output[3] = (static_cast<uint32_t>(convHighCellVoltage) >> 8) & 0xFF;
-		output[4] = static_cast<uint32_t>(convAvgCellVoltage) & 0xFF;
-		output[5] = (static_cast<uint32_t>(convAvgCellVoltage) >> 8) & 0xFF;
-		output[6] = static_cast<uint32_t>(convPackSummedVoltage) & 0xFF;
-		output[7] = (static_cast<uint32_t>(convPackSummedVoltage) >> 8) & 0xFF;
-	}
-
-	BMS_MESSAGE_0_DATA_PACKET arrayToDataPacket(uint8_t input[ARRAY_SIZE])
-	{
-		BMS_MESSAGE_0_DATA_PACKET output;
-		uint32_t preLCV = (static_cast<uint32_t>(input[1]) << 8) | input[0];
-		uint32_t preHCV = (static_cast<uint32_t>(input[3]) << 8) | input[2];
-		uint32_t preACV = (static_cast<uint32_t>(input[5]) << 8) | input[4];
-		uint32_t prePCV = (static_cast<uint32_t>(input[7]) << 8) | input[6];
-		output.lowCellVoltage = static_cast<float>(preLCV)/10000;
-		output.highCellVoltage = static_cast<float>(preHCV)/10000;
-		output.avgCellVoltage = static_cast<float>(preACV)/10000;
-		output.packSummedVoltage = static_cast<float>(prePCV)/1000;
-
-		return output;
-	}
+	output[0] = static_cast<uint32_t>(convLowCellVoltage) & 0xFF;
+	output[1] = (static_cast<uint32_t>(convLowCellVoltage) >> 8) & 0xFF;
+	output[2] = static_cast<uint32_t>(convHighCellVoltage) & 0xFF;
+	output[3] = (static_cast<uint32_t>(convHighCellVoltage) >> 8) & 0xFF;
+	output[4] = static_cast<uint32_t>(convAvgCellVoltage) & 0xFF;
+	output[5] = (static_cast<uint32_t>(convAvgCellVoltage) >> 8) & 0xFF;
+	output[6] = static_cast<uint32_t>(convPackSummedVoltage) & 0xFF;
+	output[7] = (static_cast<uint32_t>(convPackSummedVoltage) >> 8) & 0xFF;
 }
 
-void BMS_MESSAGE_0::fillTransmitBuffer(void)
+BMS_MESSAGE_0_DATA_PACKET BMS_MESSAGE_0::arrayToDataPacket(uint8_t input[NUM_BYTES])
 {
-	BMS0_HELPER::dataPacketToArray(this->txData, this->transmitBuffer);
+	BMS_MESSAGE_0_DATA_PACKET output;
+	uint32_t preLCV = (static_cast<uint32_t>(input[1]) << 8) | input[0];
+	uint32_t preHCV = (static_cast<uint32_t>(input[3]) << 8) | input[2];
+	uint32_t preACV = (static_cast<uint32_t>(input[5]) << 8) | input[4];
+	uint32_t prePCV = (static_cast<uint32_t>(input[7]) << 8) | input[6];
+	output.lowCellVoltage = static_cast<float>(preLCV)/10000;
+	output.highCellVoltage = static_cast<float>(preHCV)/10000;
+	output.avgCellVoltage = static_cast<float>(preACV)/10000;
+	output.packSummedVoltage = static_cast<float>(prePCV)/1000;
+
+	return output;
 }
+
 //Public Function Definitions
 BMS_MESSAGE_0::BMS_MESSAGE_0():
-SUBSYSTEM_DATA_MODULE{subsystem_info::BMS0_MSG_ID,subsystem_info::BMS0_MSG_LENGTH, false}
+SUBSYSTEM_DATA_MODULE_TEMPLATE_INTERFACE<BMS_MESSAGE_0, BMS_MESSAGE_0_DATA_PACKET>{subsystem_info::BMS0_MSG_ID,subsystem_info::BMS0_MSG_LENGTH, false}
 {}
 
-BMS_MESSAGE_0_DATA_PACKET BMS_MESSAGE_0::GetOldestDataPacket(bool* success)
-{
-	BMS_MESSAGE_0_DATA_PACKET returnData;
-    if(success)
-    {
-        uint8_t* raw_data = this->storageFifo.PopFront(success);
-
-        //Only do the conversions if we successfully extracted from the fifo
-        if(*success)
-        {
-        	returnData = BMS0_HELPER::arrayToDataPacket(raw_data);
-        }
-    }
-    return returnData;
-}

--- a/dev-board/subsystem-can-driver/bms-data-module.hpp
+++ b/dev-board/subsystem-can-driver/bms-data-module.hpp
@@ -42,47 +42,31 @@ struct BMS_MESSAGE_0_DATA_PACKET
     float packSummedVoltage;
 };
 
-namespace BMS0_HELPER
-{
-	static constexpr uint8_t ARRAY_SIZE = 8;
-	/**
-	 * @brief This function converts @input to fill the encoded @output array
-	 * @param input: Data to be converted
-	 * @param output: Array that should be allocated at least @ARRAY_SIZE bytes
-	 */
-	void dataPacketToArray(BMS_MESSAGE_0_DATA_PACKET input, uint8_t output[ARRAY_SIZE]);
-	/**
-	 * @brief This converts the encoded @input array to a data packet
-	 * @param input: Encoded array of @ARRAY_SIZE bytes
-	 * @retval A data packet
-	 */
-	BMS_MESSAGE_0_DATA_PACKET arrayToDataPacket(uint8_t input[ARRAY_SIZE]);
-}
-
-class BMS_MESSAGE_0 final: public SUBSYSTEM_DATA_MODULE
+class BMS_MESSAGE_0 final: public SUBSYSTEM_DATA_MODULE_TEMPLATE_INTERFACE<BMS_MESSAGE_0, BMS_MESSAGE_0_DATA_PACKET>
 {
 public:
 //Constructors
 BMS_MESSAGE_0();
+//Public Constants
+static constexpr uint8_t NUM_BYTES = 8;
 //Public Function Prototypes
 /**
- * @brief This is used to get the first in data packet.
- * @param success: returns true if there was data to get, false if the fifo was empty
- * @return Corresponding mppt data packet
+ * @brief This function converts @input to fill the encoded @output array
+ * @param input: Data to be converted
+ * @param output: Array that should be allocated at least @ARRAY_SIZE bytes
  */
-BMS_MESSAGE_0_DATA_PACKET GetOldestDataPacket(bool* success);
-//Public Constants
-
+static void dataPacketToArray(BMS_MESSAGE_0_DATA_PACKET input, uint8_t output[NUM_BYTES]);
+/**
+ * @brief This converts the encoded @input array to a data packet
+ * @param input: Encoded array of @ARRAY_SIZE bytes
+ * @retval A data packet
+ */
+static BMS_MESSAGE_0_DATA_PACKET arrayToDataPacket(uint8_t input[NUM_BYTES]);
 //Public Variables
 /**
  * @brief Fill this out prior to calling SendData()
  */
 BMS_MESSAGE_0_DATA_PACKET txData;
-private:
-//Private Constants
-//Private Variables
-//Private Function Prototypes
-void fillTransmitBuffer(void) override;
 };
 
 #endif //End Header Guard

--- a/dev-board/subsystem-can-driver/mppt-data-module.cpp
+++ b/dev-board/subsystem-can-driver/mppt-data-module.cpp
@@ -27,66 +27,43 @@
 //Private Function Definitions
 
 //Protected Function Definitions
-namespace MPPT0_HELPER
+void MPPT_MESSAGE_0::dataPacketToArray(MPPT_MESSAGE_0_DATA_PACKET input, uint8_t output[NUM_BYTES])
 {
-	void dataPacketToArray(MPPT_MESSAGE_0_DATA_PACKET input, uint8_t output[ARRAY_SIZE])
-	{
-		assert_param(output != nullptr);
+	assert_param(output != nullptr);
 
-		float convArrayVoltage = input.arrayVoltage * 100;
-		float convArrayCurrent = input.arrayCurrent * 100;
-		float convBatteryVoltage = input.batteryVoltage * 100;
-		float convMpptTemperature = input.mpptTemperature * 100;
+	float convArrayVoltage = input.arrayVoltage * 100;
+	float convArrayCurrent = input.arrayCurrent * 100;
+	float convBatteryVoltage = input.batteryVoltage * 100;
+	float convMpptTemperature = input.mpptTemperature * 100;
 
-		output[0] = static_cast<uint32_t>(convArrayVoltage) & 0xFF;
-		output[1] = (static_cast<uint32_t>(convArrayVoltage) >> 8) & 0xFF;
-		output[2] = static_cast<uint32_t>(convArrayCurrent) & 0xFF;
-		output[3] = (static_cast<uint32_t>(convArrayCurrent) >> 8) & 0xFF;
-		output[4] = static_cast<uint32_t>(convBatteryVoltage) & 0xFF;
-		output[5] = (static_cast<uint32_t>(convBatteryVoltage) >> 8) & 0xFF;
-		output[6] = static_cast<uint32_t>(convMpptTemperature) & 0xFF;
-		output[7] = (static_cast<uint32_t>(convMpptTemperature) >> 8) & 0xFF;
-	}
-
-	MPPT_MESSAGE_0_DATA_PACKET arrayToDataPacket(uint8_t input[ARRAY_SIZE])
-	{
-		assert_param(input != nullptr);
-
-		MPPT_MESSAGE_0_DATA_PACKET output;
-		uint32_t preArrayVoltage = (static_cast<uint32_t>(input[1]) << 8) | input[0];
-		uint32_t preArrayCurrent = (static_cast<uint32_t>(input[3]) << 8) | input[2];
-		uint32_t preBatteryVoltage = (static_cast<uint32_t>(input[5]) << 8) | input[4];
-		uint32_t preMpptTemperature = (static_cast<uint32_t>(input[7]) << 8) | input[6];
-		output.arrayVoltage = static_cast<float>(preArrayVoltage)/100;
-		output.arrayCurrent = static_cast<float>(preArrayCurrent)/100;
-		output.batteryVoltage = static_cast<float>(preBatteryVoltage)/100;
-		output.mpptTemperature = static_cast<float>(preMpptTemperature)/100;
-
-		return output;
-	}
+	output[0] = static_cast<uint32_t>(convArrayVoltage) & 0xFF;
+	output[1] = (static_cast<uint32_t>(convArrayVoltage) >> 8) & 0xFF;
+	output[2] = static_cast<uint32_t>(convArrayCurrent) & 0xFF;
+	output[3] = (static_cast<uint32_t>(convArrayCurrent) >> 8) & 0xFF;
+	output[4] = static_cast<uint32_t>(convBatteryVoltage) & 0xFF;
+	output[5] = (static_cast<uint32_t>(convBatteryVoltage) >> 8) & 0xFF;
+	output[6] = static_cast<uint32_t>(convMpptTemperature) & 0xFF;
+	output[7] = (static_cast<uint32_t>(convMpptTemperature) >> 8) & 0xFF;
 }
 
-void MPPT_MESSAGE_0::fillTransmitBuffer(void)
+MPPT_MESSAGE_0_DATA_PACKET MPPT_MESSAGE_0::arrayToDataPacket(uint8_t input[NUM_BYTES])
 {
-	MPPT0_HELPER::dataPacketToArray(this->txData, this->transmitBuffer);
+	assert_param(input != nullptr);
+
+	MPPT_MESSAGE_0_DATA_PACKET output;
+	uint32_t preArrayVoltage = (static_cast<uint32_t>(input[1]) << 8) | input[0];
+	uint32_t preArrayCurrent = (static_cast<uint32_t>(input[3]) << 8) | input[2];
+	uint32_t preBatteryVoltage = (static_cast<uint32_t>(input[5]) << 8) | input[4];
+	uint32_t preMpptTemperature = (static_cast<uint32_t>(input[7]) << 8) | input[6];
+	output.arrayVoltage = static_cast<float>(preArrayVoltage)/100;
+	output.arrayCurrent = static_cast<float>(preArrayCurrent)/100;
+	output.batteryVoltage = static_cast<float>(preBatteryVoltage)/100;
+	output.mpptTemperature = static_cast<float>(preMpptTemperature)/100;
+
+	return output;
 }
+
 //Public Function Definitions
 MPPT_MESSAGE_0::MPPT_MESSAGE_0():
-SUBSYSTEM_DATA_MODULE{subsystem_info::MPPT0_MSG_ID,subsystem_info::MPPT0_MSG_LENGTH, false}
+SUBSYSTEM_DATA_MODULE_TEMPLATE_INTERFACE<MPPT_MESSAGE_0, MPPT_MESSAGE_0_DATA_PACKET>{subsystem_info::MPPT0_MSG_ID,subsystem_info::MPPT0_MSG_LENGTH, false}
 {}
-
-MPPT_MESSAGE_0_DATA_PACKET MPPT_MESSAGE_0::GetOldestDataPacket(bool* success)
-{
-    MPPT_MESSAGE_0_DATA_PACKET returnData;
-    if(success)
-    {
-        uint8_t* raw_data = this->storageFifo.PopFront(success);
-
-        //Only do the conversions if we successfully extracted from the fifo
-        if(*success)
-        {
-        	returnData = MPPT0_HELPER::arrayToDataPacket(raw_data);
-        }
-    }
-    return returnData;
-}

--- a/dev-board/subsystem-can-driver/mppt-data-module.hpp
+++ b/dev-board/subsystem-can-driver/mppt-data-module.hpp
@@ -42,47 +42,31 @@ struct MPPT_MESSAGE_0_DATA_PACKET
     float mpptTemperature;
 };
 
-namespace MPPT0_HELPER
-{
-	static constexpr uint8_t ARRAY_SIZE = 8;
-	/**
-	 * @brief This function converts @input to fill the encoded @output array
-	 * @param input: Data to be converted
-	 * @param output: Array that should be allocated at least @ARRAY_SIZE bytes
-	 */
-	void dataPacketToArray(MPPT_MESSAGE_0_DATA_PACKET input, uint8_t output[ARRAY_SIZE]);
-	/**
-	 * @brief This converts the encoded @input array to a data packet
-	 * @param input: Encoded array of @ARRAY_SIZE bytes
-	 * @retval A data packet
-	 */
-	MPPT_MESSAGE_0_DATA_PACKET arrayToDataPacket(uint8_t input[ARRAY_SIZE]);
-}
-
-class MPPT_MESSAGE_0 final: public SUBSYSTEM_DATA_MODULE
+class MPPT_MESSAGE_0 final: public SUBSYSTEM_DATA_MODULE_TEMPLATE_INTERFACE<MPPT_MESSAGE_0, MPPT_MESSAGE_0_DATA_PACKET>
 {
 public:
 //Constructors
 MPPT_MESSAGE_0();
+//Public Constants
+static constexpr uint8_t NUM_BYTES = 8;
 //Public Function Prototypes
 /**
- * @brief This is used to get the first in data packet.
- * @param success: returns true if there was data to get, false if the fifo was empty
- * @return Corresponding mppt data packet
+ * @brief This function converts @input to fill the encoded @output array
+ * @param input: Data to be converted
+ * @param output: Array that should be allocated at least @ARRAY_SIZE bytes
  */
-MPPT_MESSAGE_0_DATA_PACKET GetOldestDataPacket(bool* success);
-//Public Constants
-
+static void dataPacketToArray(MPPT_MESSAGE_0_DATA_PACKET input, uint8_t output[NUM_BYTES]);
+/**
+ * @brief This converts the encoded @input array to a data packet
+ * @param input: Encoded array of @ARRAY_SIZE bytes
+ * @retval A data packet
+ */
+static MPPT_MESSAGE_0_DATA_PACKET arrayToDataPacket(uint8_t input[NUM_BYTES]);
 //Public Variables
 /**
  * @brief Fill this out prior to calling SendData()
  */
 MPPT_MESSAGE_0_DATA_PACKET txData;
-private:
-//Private Constants
-//Private Variables
-//Private Function Prototypes
-void fillTransmitBuffer(void) override;
 };
 
 #endif //End Header Guard


### PR DESCRIPTION
This class template utilizes CRTP to implement templated functions to reduce the amount of copy and pasting for the message children. This means the the message children just need to define their variable and how they convert from a byte stream to their specific data structure and vice versa.